### PR TITLE
fix hasDatabaseTable method

### DIFF
--- a/lib/connect-db2.js
+++ b/lib/connect-db2.js
@@ -493,6 +493,10 @@ module.exports = function (session) {
 
             var count = !!rows[0] ? rows[0].count : 0;
 
+            if(typeof count === 'string'){
+                count = Number(count);
+            }
+            
             return fn(null, !!count);
         });
     };


### PR DESCRIPTION
I was using this lib and the method "hasDatabaseTable" was always returning true. 

After looking at the code I found that the "count" variable was a string instead of a number.
When using the logical not operator on that string, it returns false not matter its content (including '0'). When you apply the operator again, it returns true which was the return of the hasDatabaseTable method. So, that is the reason the method hasDatabaseTable was always returning true.

I don't know if the count variable is always a string, so I added a conditional to check if it is a string, and if it is, I convert it to number so the "!!count" at the end of the method should work.

If it is a number, it will skip the block included in the condition and if the number conversion returns "NaN", the method will return true as it was before.


